### PR TITLE
Add dice-only checkbox to composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # discourse-dice-comment
+
+This plugin adds a **"주사위댓글 전용"** checkbox to the topic composer. When checked, a `dice_only` custom field is saved on the created topic.

--- a/assets/javascripts/discourse-dice-comment/add-dice-checkbox.js.es6
+++ b/assets/javascripts/discourse-dice-comment/add-dice-checkbox.js.es6
@@ -1,0 +1,24 @@
+import { withPluginApi } from 'discourse/lib/plugin-api';
+
+function initialize(api) {
+  api.addComposerFields({ dice_only: false });
+
+  api.decorateWidget('composer-fields:after', helper => {
+    const model = helper.widget.model;
+    return helper.h('label.dice-only', [
+      helper.h('input.dice-only-checkbox', {
+        type: 'checkbox',
+        checked: model.dice_only,
+        onchange: event => (model.dice_only = event.target.checked)
+      }),
+      helper.h('span', helper.widget._t('dice_comment.checkbox'))
+    ]);
+  });
+}
+
+export default {
+  name: 'dice-comment-checkbox',
+  initialize() {
+    withPluginApi('0.8.7', initialize);
+  }
+};

--- a/assets/javascripts/discourse-dice-comment/initialize-dice-only.js.es6
+++ b/assets/javascripts/discourse-dice-comment/initialize-dice-only.js.es6
@@ -1,0 +1,28 @@
+import { withPluginApi } from 'discourse/lib/plugin-api';
+
+function initialize(api) {
+  api.addComposerFields({ dice_only: false });
+
+  api.modifyClass('controller:composer', {
+    pluginId: 'discourse-dice-comment',
+    actions: {
+      publish() {
+        if (this.get('model.action') === 'createTopic') {
+          this.get('composer').set('dice_only', this.get('model.fields.dice_only'));
+        }
+        return this._super(...arguments);
+      }
+    }
+  });
+
+  api.decorateComposer((composer) => {
+    composer.addField('dice_only');
+  });
+}
+
+export default {
+  name: 'discourse-dice-comment',
+  initialize() {
+    withPluginApi('0.8.7', initialize);
+  }
+};

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  js:
+    dice_comment:
+      checkbox: "Dice reply only"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# name: discourse-dice-comment
+# about: Adds a dice-only custom field to topics
+# version: 0.1
+# authors: Codex
+
+after_initialize do
+  # Store dice_only field when topic is created
+  on(:topic_created) do |topic, params, user|
+    if params[:dice_only].present?
+      topic.custom_fields['dice_only'] = params[:dice_only]
+      topic.save_custom_fields
+    end
+  end
+
+  add_to_serializer(:topic_view, :dice_only) do
+    object.topic.custom_fields['dice_only']
+  end
+  add_to_serializer(:topic_view, :include_dice_only?) do
+    object.topic.custom_fields.key?('dice_only')
+  end
+end


### PR DESCRIPTION
## Summary
- add plugin skeleton with `dice_only` custom field saved on topic
- include initializer JS that adds a '주사위댓글 전용' checkbox in the topic composer
- add basic English locale
- update README to describe feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687455d1f2f4832c9f59a1d48e048f14