### PR TITLE
Fix composer field initialization

### DIFF
--- a/assets/javascripts/discourse/initializers/add-dice-checkbox.js
+++ b/assets/javascripts/discourse/initializers/add-dice-checkbox.js
@@ -1,10 +1,12 @@
 import { withPluginApi } from 'discourse/lib/plugin-api';
 
 function initialize(api) {
-  api.addComposerFields({ dice_only: false, dice_min: 1, dice_max: 100 });
 
   api.decorateWidget('composer-fields:after', helper => {
     const model = helper.widget.model;
+    if (model.dice_only === undefined) model.dice_only = false;
+    if (model.dice_min === undefined) model.dice_min = 1;
+    if (model.dice_max === undefined) model.dice_max = 100;
     const checkbox = helper.h('label.dice-only', [
       helper.h('input.dice-only-checkbox', {
         type: 'checkbox',

--- a/assets/javascripts/discourse/initializers/initialize-dice-only.js
+++ b/assets/javascripts/discourse/initializers/initialize-dice-only.js
@@ -1,16 +1,15 @@
 import { withPluginApi } from 'discourse/lib/plugin-api';
 
 function initialize(api) {
-  api.addComposerFields({ dice_only: false, dice_min: 1, dice_max: 100 });
 
   api.modifyClass('controller:composer', {
     pluginId: 'discourse-dice-comment',
     actions: {
       publish() {
         if (this.get('model.action') === 'createTopic') {
-          this.get('composer').set('dice_only', this.get('model.fields.dice_only'));
-          this.get('composer').set('dice_min', this.get('model.fields.dice_min'));
-          this.get('composer').set('dice_max', this.get('model.fields.dice_max'));
+          this.get('composer').set('dice_only', this.get('model.dice_only'));
+          this.get('composer').set('dice_min', this.get('model.dice_min'));
+          this.get('composer').set('dice_max', this.get('model.dice_max'));
         }
         return this._super(...arguments);
       }
@@ -21,6 +20,9 @@ function initialize(api) {
     composer.addField('dice_only');
     composer.addField('dice_min');
     composer.addField('dice_max');
+    if (composer.dice_only === undefined) composer.dice_only = false;
+    if (composer.dice_min === undefined) composer.dice_min = 1;
+    if (composer.dice_max === undefined) composer.dice_max = 100;
   });
 }
 


### PR DESCRIPTION
## Summary
- remove `addComposerFields` calls which caused errors on plugin load
- initialize dice composer fields directly when the composer is decorated

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68745e893090832c859644d235288efc