### PR TITLE
Fix dice-only checkbox location and max value input

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This plugin adds a **"주사위댓글 전용"** checkbox to the topic composer. When checked, the topic becomes dice only and normal replies are disabled.
 
-Dice-only topics allow users to roll a random number as a reply using the **주사위** button. The range can be customised when creating the topic.
+Dice-only topics allow users to roll a random number as a reply using the **주사위** button. When enabling dice only, you may set the maximum dice value (default 100, minimum 0).

--- a/assets/javascripts/discourse/initializers/add-dice-checkbox.js
+++ b/assets/javascripts/discourse/initializers/add-dice-checkbox.js
@@ -2,11 +2,12 @@ import { withPluginApi } from 'discourse/lib/plugin-api';
 
 function initialize(api) {
 
-  api.decorateWidget('composer-fields:after', helper => {
+  api.decorateWidget('composer-controls:after', helper => {
     const model = helper.widget.model;
     if (model.dice_only === undefined) model.dice_only = false;
-    if (model.dice_min === undefined) model.dice_min = 1;
+    if (model.dice_min === undefined) model.dice_min = 0;
     if (model.dice_max === undefined) model.dice_max = 100;
+
     const checkbox = helper.h('label.dice-only', [
       helper.h('input.dice-only-checkbox', {
         type: 'checkbox',
@@ -16,22 +17,18 @@ function initialize(api) {
       helper.h('span', helper.widget._t('dice_comment.checkbox'))
     ]);
 
-    const rangeInputs = model.dice_only
+    const maxInput = model.dice_only
       ? helper.h('div.dice-range', [
-          helper.h('input.dice-min', {
-            type: 'number',
-            value: model.dice_min,
-            onchange: e => (model.dice_min = parseInt(e.target.value, 10))
-          }),
           helper.h('input.dice-max', {
             type: 'number',
             value: model.dice_max,
+            min: 0,
             onchange: e => (model.dice_max = parseInt(e.target.value, 10))
           })
         ])
       : null;
 
-    return helper.h('div.dice-only-wrapper', [checkbox, rangeInputs]);
+    return helper.h('div.dice-only-wrapper', [checkbox, maxInput]);
   });
 }
 

--- a/assets/javascripts/discourse/initializers/initialize-dice-only.js
+++ b/assets/javascripts/discourse/initializers/initialize-dice-only.js
@@ -22,7 +22,7 @@ function initialize(api) {
       composer.addField('dice_min');
       composer.addField('dice_max');
       if (composer.dice_only === undefined) composer.dice_only = false;
-      if (composer.dice_min === undefined) composer.dice_min = 1;
+      if (composer.dice_min === undefined) composer.dice_min = 0;
       if (composer.dice_max === undefined) composer.dice_max = 100;
     });
   }

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,7 @@ after_initialize do
 
       min = topic.custom_fields['dice_min'].to_i
       max = topic.custom_fields['dice_max'].to_i
-      min = 1 if min <= 0
+      min = 0 if min < 0
       max = 100 if max <= 0 || max < min
 
       roll = rand(min..max)


### PR DESCRIPTION
## Summary
- add checkbox at `composer-controls:after`
- default min dice value to 0 and show only max input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874a7847d94832cb7696cec8dde37ed