### PR TITLE
Refactor plugin to follow official structure

### DIFF
--- a/app/controllers/discourse_dice_comment/roll_controller.rb
+++ b/app/controllers/discourse_dice_comment/roll_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ::DiscourseDiceComment
+  class RollController < ::ApplicationController
+    requires_plugin 'discourse-dice-comment'
+    before_action :ensure_logged_in
+
+    def create
+      topic = Topic.find(params[:topic_id])
+      raise Discourse::NotFound unless topic.custom_fields['dice_only']
+
+      min = topic.custom_fields['dice_min'].to_i
+      max = topic.custom_fields['dice_max'].to_i
+      min = 0 if min < 0
+      max = 100 if max <= 0 || max < min
+
+      roll = rand(min..max)
+      raw = "\u{1F3B2} #{roll}! #{current_user.username}\uB2D8\uC758 \uC6B4\uBA85\uC740!?"
+      PostCreator.create!(current_user, topic_id: topic.id, raw: raw)
+
+      render json: success_json
+    end
+  end
+end

--- a/app/serializers/topic_view_serializer_extension.rb
+++ b/app/serializers/topic_view_serializer_extension.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+TopicViewSerializer.class_eval do
+  attributes :dice_only, :dice_min, :dice_max
+
+  def dice_only
+    object.topic.custom_fields['dice_only']
+  end
+
+  def dice_min
+    object.topic.custom_fields['dice_min']
+  end
+
+  def dice_max
+    object.topic.custom_fields['dice_max']
+  end
+end

--- a/lib/discourse_dice_comment/engine.rb
+++ b/lib/discourse_dice_comment/engine.rb
@@ -1,0 +1,6 @@
+module ::DiscourseDiceComment
+  class Engine < ::Rails::Engine
+    engine_name "discourse_dice_comment"
+    isolate_namespace DiscourseDiceComment
+  end
+end


### PR DESCRIPTION
## Summary
- register topic custom field types and assets
- split controller and serializer into `app` folder
- define plugin engine and routes
- keep JS initializers using Plugin API v0.8.7

## Testing
- `bundle exec rake db:migrate` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875a1642c88832ca72ead2f99b41dd0