### PR TITLE
Add dice post custom fields and icon

### DIFF
--- a/app/controllers/discourse_dice_comment/roll_controller.rb
+++ b/app/controllers/discourse_dice_comment/roll_controller.rb
@@ -27,7 +27,11 @@ module ::DiscourseDiceComment
       post = PostCreator.create!(
         current_user,
         topic_id: topic.id,
-        raw: raw
+        raw: raw,
+        custom_fields: {
+          is_dice: true,
+          dice_value: roll.to_s
+        }
       )
 
       render json: success_json

--- a/app/serializers/post_serializer_extension.rb
+++ b/app/serializers/post_serializer_extension.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+PostSerializer.class_eval do
+  attributes :is_dice, :dice_value
+
+  def is_dice
+    object.custom_fields['is_dice']
+  end
+
+  def include_is_dice?
+    object.custom_fields.key?('is_dice')
+  end
+
+  def dice_value
+    object.custom_fields['dice_value']
+  end
+
+  def include_dice_value?
+    object.custom_fields.key?('dice_value')
+  end
+end

--- a/assets/javascripts/discourse/initializers/dice-post-icon.js
+++ b/assets/javascripts/discourse/initializers/dice-post-icon.js
@@ -1,0 +1,15 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dice-post-icon",
+  initialize() {
+    withPluginApi("0.8.7", (api) => {
+      api.decorateWidget("post-menu:before", (helper) => {
+        const post = helper.getModel && helper.getModel();
+        if (post?.custom_fields?.is_dice?.toString() === "true") {
+          return helper.h("span.dice-post-icon", "\u{1F3B2}");
+        }
+      });
+    });
+  },
+};

--- a/assets/stylesheets/common/dice-comment.scss
+++ b/assets/stylesheets/common/dice-comment.scss
@@ -5,3 +5,7 @@ body.dice-only-topic .topic-footer-main-buttons button.create {
 body.dice-only-topic .topic-footer-main-buttons button.roll-dice {
   display: inline-block;
 }
+
+.dice-post-icon {
+  margin-right: 0.25em;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,6 +13,7 @@ register_asset 'stylesheets/common/dice-comment.scss'
 after_initialize do
   require_relative 'lib/discourse_dice_comment/engine'
   load File.expand_path('app/serializers/topic_view_serializer_extension.rb', __dir__)
+  load File.expand_path('app/serializers/post_serializer_extension.rb', __dir__)
   load File.expand_path('app/controllers/discourse_dice_comment/roll_controller.rb', __dir__)
 
   Discourse::Application.routes.append do
@@ -57,6 +58,31 @@ after_initialize do
 
     add_to_serializer(:topic_list_item, field[:name].to_sym) do
       object.send(field[:name])
+    end
+  end
+
+  post_fields = [
+    { name: 'is_dice', type: 'boolean' },
+    { name: 'dice_value', type: 'string' }
+  ]
+
+  post_fields.each do |field|
+    register_post_custom_field_type(field[:name], field[:type])
+
+    add_to_class(:post, field[:name].to_sym) do
+      custom_fields[field[:name]]
+    end
+
+    add_to_class(:post, "#{field[:name]}=") do |value|
+      custom_fields[field[:name]] = value
+    end
+
+    add_to_serializer(:post, field[:name].to_sym) do
+      object.custom_fields[field[:name]]
+    end
+
+    add_to_serializer(:post, "include_#{field[:name]}?".to_sym) do
+      object.custom_fields.key?(field[:name])
     end
   end
 


### PR DESCRIPTION
## Summary
- store dice roll results on posts via `is_dice` and `dice_value` custom fields
- expose these fields in a new post serializer extension
- show a 🎲 emoji before the post menu for dice posts
- minor CSS for icon spacing

## Testing
- `ruby -c app/serializers/post_serializer_extension.rb`
- `ruby -c app/controllers/discourse_dice_comment/roll_controller.rb`
- `ruby -c plugin.rb`


------
https://chatgpt.com/codex/tasks/task_e_688994def5f8832c8a1e751c67253745