### PR TITLE
Fix dice icon visibility

### DIFF
--- a/app/serializers/post_serializer_extension.rb
+++ b/app/serializers/post_serializer_extension.rb
@@ -4,7 +4,8 @@ PostSerializer.class_eval do
   attributes :is_dice, :dice_value
 
   def is_dice
-    object.custom_fields['is_dice']
+    value = object.custom_fields['is_dice']
+    [true, "true", "t", "1"].include?(value)
   end
 
   def include_is_dice?

--- a/assets/javascripts/discourse/initializers/dice-post-icon.js
+++ b/assets/javascripts/discourse/initializers/dice-post-icon.js
@@ -6,8 +6,8 @@ export default {
     withPluginApi("0.8.7", (api) => {
       api.decorateWidget("post-menu:before", (helper) => {
         const post = helper.getModel && helper.getModel();
-        if (post?.custom_fields?.is_dice?.toString() === "true") {
-          return helper.h("span.dice-post-icon", "\u{1F3B2}");
+        if (post?.is_dice) {
+          return helper.h("span.dice-post-icon", "🎲 주사위 댓글");
         }
       });
     });


### PR DESCRIPTION
## Summary
- fix is_dice boolean value by casting to boolean
- show the dice label for dice posts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68899e052478832c9ffb9b8d9304482a