### PR TITLE
Fix dice icon placement

### DIFF
--- a/assets/javascripts/discourse/initializers/dice-post-icon.js
+++ b/assets/javascripts/discourse/initializers/dice-post-icon.js
@@ -7,7 +7,11 @@ export default {
       api.decorateWidget("post-menu:before", (helper) => {
         const post = helper.getModel && helper.getModel();
         if (post?.is_dice) {
-          return helper.h("span.dice-post-icon", "🎲 주사위 댓글");
+          return helper.h(
+            "li",
+            { className: "dice-post-icon" },
+            "🎲 주사위 댓글"
+          );
         }
       });
     });

--- a/assets/stylesheets/common/dice-comment.scss
+++ b/assets/stylesheets/common/dice-comment.scss
@@ -8,4 +8,6 @@ body.dice-only-topic .topic-footer-main-buttons button.roll-dice {
 
 .dice-post-icon {
   margin-right: 0.25em;
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
## Summary
- display dice indicator inside the post menu
- style dice icon so it aligns with other menu buttons

## Testing
- `npm test` *(fails: could not read package.json)*
- `bundle exec rake` *(fails: could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6889a79438f4832c961748cd7c95d269