### PR TITLE
Show dice indicator in post menu

### DIFF
--- a/assets/javascripts/discourse/initializers/dice-post-icon.js
+++ b/assets/javascripts/discourse/initializers/dice-post-icon.js
@@ -3,17 +3,31 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "dice-post-icon",
   initialize() {
-    withPluginApi("0.8.7", (api) => {
-      api.decorateWidget("post-menu:before", (helper) => {
-        const post = helper.getModel && helper.getModel();
-        if (post?.is_dice) {
-          return helper.h(
-            "li",
-            { className: "dice-post-icon" },
-            "🎲 주사위 댓글"
+    withPluginApi("1.34.0", (api) => {
+      api.registerValueTransformer(
+        "post-menu-buttons",
+        ({ value: dag, context: { post, buttonKeys } }) => {
+          if (!post?.is_dice) {
+            return;
+          }
+
+          const key = "dice-post-indicator";
+          if (dag.has(key)) {
+            return;
+          }
+
+          dag.addAfter(
+            buttonKeys.REPLY,
+            key,
+            {
+              id: key,
+              translatedLabel: "dice_comment.dice_post",
+              className: "dice-post-icon",
+              title: "dice_comment.dice_post",
+            }
           );
         }
-      });
+      );
     });
   },
 };

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,3 +3,4 @@ en:
     dice_comment:
       checkbox: "Dice reply only"
       roll: "Roll Dice"
+      dice_post: "Dice Comment"

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -3,3 +3,4 @@ ko:
     dice_comment:
       checkbox: "Dice reply only"
       roll: "Roll Dice"
+      dice_post: "주사위 댓글"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,4 @@
 en:
   dice_comment:
     roll_success: "dice rolled"
+    dice_post: "Dice Comment"

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -1,3 +1,4 @@
 ko:
   dice_comment:
     roll_success: "dice rolled"
+    dice_post: "주사위 댓글"


### PR DESCRIPTION
## Summary
- show dice comment indicator via `registerValueTransformer`
- add translations for the indicator

## Testing
- `find . -path '*spec*' -not -path '*/.git/*' | head`

------
https://chatgpt.com/codex/tasks/task_e_6889b16340f0832caf950d37aa641b19