### PR TITLE
Update post menu button API

### DIFF
--- a/assets/javascripts/discourse/initializers/dice-post-icon.js
+++ b/assets/javascripts/discourse/initializers/dice-post-icon.js
@@ -3,31 +3,25 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "dice-post-icon",
   initialize() {
-    withPluginApi("1.34.0", (api) => {
-      api.registerValueTransformer(
-        "post-menu-buttons",
-        ({ value: dag, context: { post, buttonKeys } }) => {
-          if (!post?.is_dice) {
-            return;
-          }
-
-          const key = "dice-post-indicator";
-          if (dag.has(key)) {
-            return;
-          }
-
-          dag.addAfter(
-            buttonKeys.REPLY,
-            key,
-            {
-              id: key,
-              translatedLabel: "dice_comment.dice_post",
-              className: "dice-post-icon",
-              title: "dice_comment.dice_post",
-            }
-          );
+    withPluginApi("0.8.13", (api) => {
+      api.addPostMenuButton("dice-post-indicator", (post) => {
+        if (!post?.is_dice) {
+          return;
         }
-      );
+
+        return {
+          action: "dicePostIndicator",
+          icon: "gamepad",
+          label: "dice_comment.dice_post",
+          className: "dice-post-icon",
+          title: "dice_comment.dice_post",
+          position: "second-last",
+        };
+      });
+
+      api.attachWidgetAction("post", "dicePostIndicator", function () {
+        alert("\ud83c\udfb2 \uc8fc\uc0ac\uc704 \uad74\ub9ac\uae30!");
+      });
     });
   },
 };


### PR DESCRIPTION
## Summary
- modernize dice post icon integration

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889b69c35a0832cb9cd81d763ec9678