### PR TITLE
Limit dice rolls to once per topic

### DIFF
--- a/app/serializers/topic_view_serializer_extension.rb
+++ b/app/serializers/topic_view_serializer_extension.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 TopicViewSerializer.class_eval do
-  attributes :dice_only, :dice_max
+  attributes :dice_only, :dice_max, :current_user_has_dice_post
 
   def dice_only
     object.topic.custom_fields["dice_only"]
@@ -17,5 +17,23 @@ TopicViewSerializer.class_eval do
 
   def include_dice_max?
     object.topic.custom_fields.key?("dice_max")
+  end
+
+  def current_user_has_dice_post
+    user = scope.user
+    return false unless user
+
+    PostCustomField
+      .joins(:post)
+      .where(
+        name: "is_dice",
+        value: "t",
+        posts: { topic_id: object.topic.id, user_id: user.id }
+      )
+      .exists?
+  end
+
+  def include_current_user_has_dice_post?
+    scope.user.present?
   end
 end

--- a/assets/javascripts/discourse/initializers/dice-button.js
+++ b/assets/javascripts/discourse/initializers/dice-button.js
@@ -38,6 +38,11 @@ function initialize(api) {
       return;
     }
 
+    if (topic.current_user_has_dice_post) {
+      document.querySelector(".dice-roll-button")?.remove();
+      return;
+    }
+
 
     // 🎲 주사위 굴리기 버튼 삽입
     waitForElement(".topic-footer-main-buttons")
@@ -49,8 +54,6 @@ function initialize(api) {
           diceBtn.style.marginLeft = "1em";
 
           diceBtn.addEventListener("click", () => {
-            const topicId = topic.id;
-
             fetch(`/dice/roll-dice/${topic.id}`, {
               method: "POST",
               headers: {
@@ -59,7 +62,12 @@ function initialize(api) {
               },
             })
               .then((res) => {
-                if (!res.ok) throw new Error("실패");
+                if (!res.ok) {
+                  if (res.status === 403) {
+                    throw new Error("이미 주사위를 굴렸습니다.");
+                  }
+                  throw new Error("실패");
+                }
                 return res.json();
               })
               .then((data) => {
@@ -71,9 +79,11 @@ function initialize(api) {
                   //area.appendChild(resultEl);
                   //setTimeout(() => resultEl.remove(), 5000);
                 }
+                topic.current_user_has_dice_post = true;
+                document.querySelector(".dice-roll-button")?.remove();
               })
-              .catch(() => {
-                alert("❌ 주사위 굴리기에 실패했습니다.");
+              .catch((e) => {
+                alert(`❌ ${e.message || "주사위 굴리기에 실패했습니다."}`);
               });
           });
 


### PR DESCRIPTION
## Summary
- prevent users from rolling the dice multiple times in the same topic
- expose whether the current user already rolled dice for a topic and hide the button accordingly
- remove the dice-roll button after a successful roll

## Testing
- `ruby -c app/controllers/discourse_dice_comment/roll_controller.rb`
- `ruby -c app/serializers/topic_view_serializer_extension.rb`
- `node --check assets/javascripts/discourse/initializers/dice-button.js`


------
https://chatgpt.com/codex/tasks/task_e_689a884014d4832c9d0229f9a5d20011